### PR TITLE
Refactor log publishing and add new latency metrics

### DIFF
--- a/observation-service/Makefile
+++ b/observation-service/Makefile
@@ -47,7 +47,6 @@ observation-service:
 # ==================================
 
 test-observation-service: tidy vendor
-	go mod vendor
 	@echo "> Running Observation Service tests ..."
 	go test -v ./... -coverpkg ./... -gcflags=-l -race -coverprofile cover.out.tmp -tags unit,integration
 	cat cover.out.tmp | grep -v "api/api.go\|cmd\|.pb.go\|mock\|testutils\|server" > cover.out

--- a/observation-service/config/config.go
+++ b/observation-service/config/config.go
@@ -68,6 +68,8 @@ type FluentdConfig struct {
 	Port int `default:"24224"`
 	// Fluentd Tag to match messages
 	Tag string `default:"observation-service"`
+	// BufferLimit specifies maximum no. of events that can be buffered on memory
+	BufferLimit int `default:"8192"`
 
 	// BQConfig captures the config related to initializing a BQ Sink
 	BQConfig *BQConfig

--- a/observation-service/config/config.go
+++ b/observation-service/config/config.go
@@ -113,10 +113,8 @@ const (
 type LogProducerConfig struct {
 	// The type of Data Sink for Observation logs
 	Kind ObservationLoggerProducerKind `default:""`
-	// Maximum no. of Observation logs to be stored in-memory prior to flushing to Data sink
-	QueueLength int `default:"100"`
-	// Duration that specifies how often in-memory Observation logs should be flushed to Data sink
-	FlushIntervalSeconds int `default:"1"`
+	// Maximum no. of Observation logs to be stored in Go channel
+	QueueLength int `default:"100000"`
 
 	// KafkaConfig captures the config related to initializing a Kafka Producer
 	KafkaConfig *KafkaConfig

--- a/observation-service/config/config_test.go
+++ b/observation-service/config/config_test.go
@@ -56,10 +56,11 @@ func TestDefaultConfigs(t *testing.T) {
 				AutoOffsetReset:  "latest",
 			},
 			FluentdConfig: &FluentdConfig{
-				Kind: "",
-				Host: "localhost",
-				Port: 24224,
-				Tag:  "observation-service",
+				Kind:        "",
+				Host:        "localhost",
+				Port:        24224,
+				Tag:         "observation-service",
+				BufferLimit: 8192,
 				BQConfig: &BQConfig{
 					Project: "",
 					Dataset: "",
@@ -130,10 +131,11 @@ func TestLoadConfigFiles(t *testing.T) {
 						AutoOffsetReset:  "latest",
 					},
 					FluentdConfig: &FluentdConfig{
-						Kind: "",
-						Host: "localhost",
-						Port: 24224,
-						Tag:  "observation-service",
+						Kind:        "",
+						Host:        "localhost",
+						Port:        24224,
+						Tag:         "observation-service",
+						BufferLimit: 8192,
 						BQConfig: &BQConfig{
 							Project: "",
 							Dataset: "",

--- a/observation-service/config/config_test.go
+++ b/observation-service/config/config_test.go
@@ -43,9 +43,8 @@ func TestDefaultConfigs(t *testing.T) {
 			},
 		},
 		LogProducerConfig: LogProducerConfig{
-			Kind:                 "",
-			QueueLength:          100,
-			FlushIntervalSeconds: 1,
+			Kind:        "",
+			QueueLength: 100000,
 			KafkaConfig: &KafkaConfig{
 				Brokers:          "",
 				Topic:            "",
@@ -118,9 +117,8 @@ func TestLoadConfigFiles(t *testing.T) {
 					},
 				},
 				LogProducerConfig: LogProducerConfig{
-					Kind:                 "",
-					QueueLength:          100,
-					FlushIntervalSeconds: 1,
+					Kind:        "",
+					QueueLength: 100000,
 					KafkaConfig: &KafkaConfig{
 						Brokers:          "",
 						Topic:            "",

--- a/observation-service/config/example.yaml
+++ b/observation-service/config/example.yaml
@@ -1,5 +1,4 @@
-HTTPPort: 8081
-GRPCPort: 9001
+Port: 9001
 
 DeploymentConfig:
   EnvironmentType: local
@@ -21,3 +20,28 @@ SentryConfig:
   DSN: xxx.xxx.xxx
   Labels:
     App: observation-service
+
+## Eg. Consume messages asynchronously from Kafka
+# LogConsumerConfig:
+#   Kind: kafka
+#   KafkaConfig:
+#     Brokers: localhost:9092
+#     Topic: local-test-source
+
+## Eg. Produce messages to Fluentd
+# LogProducerConfig:
+#   Kind: fluentd
+#   KafkaConfig:
+#     Brokers: localhost:9092
+#     Topic: local-test-source
+  
+#   FluentdConfig:
+#     Kind: bq
+#     Host: localhost
+#     Port: 24224
+#     Tag: observation-service
+#     BufferLimit: 8192
+#     BQConfig:
+#       Project: my-bq-project
+#       Dataset: my-bq-dataset
+#       Table: my-bq-table

--- a/observation-service/go.mod
+++ b/observation-service/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/testcontainers/testcontainers-go v0.15.0
 	go.einride.tech/protobuf-bigquery v0.23.0
+	go.uber.org/automaxprocs v1.5.1
 	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.28.1
 )

--- a/observation-service/go.sum
+++ b/observation-service/go.sum
@@ -686,6 +686,7 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -862,6 +863,8 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/automaxprocs v1.5.1 h1:e1YG66Lrk73dn4qhg8WFSvhF0JuFQF0ERIp4rpuV8Qk=
+go.uber.org/automaxprocs v1.5.1/go.mod h1:BF4eumQw0P9GtnuxxovUd06vwm1o18oMzFtK66vU6XU=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=

--- a/observation-service/logger/fluentd_producer.go
+++ b/observation-service/logger/fluentd_producer.go
@@ -74,8 +74,14 @@ func (p *FluentdLogProducer) Produce(observationLog *types.ObservationLogEntry) 
 	fluentdFlushStartTime := time.Now()
 	err = p.logger.Post(p.tag, logFormattedVal)
 	if err != nil {
-		p.metricsService.LogRequestCount(http.StatusInternalServerError, monitoring.FlushObservationCount)
 		log.Error(err)
+		p.metricsService.LogRequestCount(http.StatusInternalServerError, monitoring.FlushObservationCount)
+		p.metricsService.LogLatencyHistogram(fluentdFlushStartTime, http.StatusInternalServerError, monitoring.FlushDurationMs, labels)
+		// Log E2E latency
+		labels = map[string]string{
+			"component": "e2e",
+		}
+		p.metricsService.LogLatencyHistogram(observationLog.StartTime, http.StatusInternalServerError, monitoring.FlushDurationMs, labels)
 	} else {
 		// Log fluentd latency
 		p.metricsService.LogLatencyHistogram(fluentdFlushStartTime, http.StatusOK, monitoring.FlushDurationMs, labels)

--- a/observation-service/logger/fluentd_producer.go
+++ b/observation-service/logger/fluentd_producer.go
@@ -26,7 +26,15 @@ func NewFluentdLogProducer(
 	cfg config.FluentdConfig,
 	metricsService services.MetricService,
 ) (*FluentdLogProducer, error) {
-	logger, err := fluent.New(fluent.Config{FluentPort: cfg.Port, FluentHost: cfg.Host})
+	logger, err := fluent.New(
+		fluent.Config{
+			FluentPort:             cfg.Port,
+			FluentHost:             cfg.Host,
+			Async:                  true,
+			AsyncReconnectInterval: 10000,
+			BufferLimit:            cfg.BufferLimit,
+		},
+	)
 	if err != nil {
 		log.Error(err)
 	}

--- a/observation-service/logger/fluentd_producer.go
+++ b/observation-service/logger/fluentd_producer.go
@@ -60,20 +60,18 @@ func NewFluentdLogProducer(
 }
 
 // Produce logs ObservationLog via Fluentd to the configured sink
-func (p *FluentdLogProducer) Produce(logs []*types.ObservationLogEntry) {
-	for _, observationLog := range logs {
-		logFormattedVal, err := observationLog.Value()
-		if err != nil {
-			// TODO: Send failed ObservationLog to deadletter sink
-			p.metricsService.LogRequestCount(http.StatusInternalServerError, monitoring.FlushObservationCount)
-			log.Error(err)
-		}
-		err = p.logger.Post(p.tag, logFormattedVal)
-		if err != nil {
-			p.metricsService.LogRequestCount(http.StatusInternalServerError, monitoring.FlushObservationCount)
-			log.Error(err)
-		}
-		p.metricsService.LogRequestCount(http.StatusOK, monitoring.FlushObservationCount)
-		p.metricsService.LogLatencyHistogram(observationLog.StartTime, http.StatusOK, monitoring.FlushDurationMs)
+func (p *FluentdLogProducer) Produce(observationLog *types.ObservationLogEntry) {
+	logFormattedVal, err := observationLog.Value()
+	if err != nil {
+		// TODO: Send failed ObservationLog to deadletter sink
+		p.metricsService.LogRequestCount(http.StatusInternalServerError, monitoring.FlushObservationCount)
+		log.Error(err)
 	}
+	err = p.logger.Post(p.tag, logFormattedVal)
+	if err != nil {
+		p.metricsService.LogRequestCount(http.StatusInternalServerError, monitoring.FlushObservationCount)
+		log.Error(err)
+	}
+	p.metricsService.LogRequestCount(http.StatusOK, monitoring.FlushObservationCount)
+	p.metricsService.LogLatencyHistogram(observationLog.StartTime, http.StatusOK, monitoring.FlushDurationMs)
 }

--- a/observation-service/logger/kafka_producer.go
+++ b/observation-service/logger/kafka_producer.go
@@ -92,6 +92,13 @@ func (p *KafkaLogPublisher) Produce(observationLog *types.ObservationLogEntry) {
 	}, deliveryChan)
 	if err != nil {
 		log.Error(err)
+		p.metricsService.LogRequestCount(http.StatusInternalServerError, monitoring.FlushObservationCount)
+		p.metricsService.LogLatencyHistogram(kafkaFlushStartTime, http.StatusInternalServerError, monitoring.FlushDurationMs, labels)
+		// Log E2E latency
+		labels = map[string]string{
+			"component": "e2e",
+		}
+		p.metricsService.LogLatencyHistogram(observationLog.StartTime, http.StatusInternalServerError, monitoring.FlushDurationMs, labels)
 	} else {
 		// Log kafka latency
 		p.metricsService.LogLatencyHistogram(kafkaFlushStartTime, http.StatusOK, monitoring.FlushDurationMs, labels)

--- a/observation-service/logger/noop_producer.go
+++ b/observation-service/logger/noop_producer.go
@@ -11,4 +11,4 @@ func NewNoopLogProducer() (*NoopLogProducer, error) {
 }
 
 // Produce does nothing to ObservationLog
-func (k *NoopLogProducer) Produce(log []*types.ObservationLogEntry) {}
+func (k *NoopLogProducer) Produce(log *types.ObservationLogEntry) {}

--- a/observation-service/logger/stdout_producer.go
+++ b/observation-service/logger/stdout_producer.go
@@ -14,8 +14,6 @@ func NewStdOutLogProducer() (*StdOutLogProducer, error) {
 }
 
 // Produce logs ObservationLog to standard output
-func (p *StdOutLogProducer) Produce(logs []*types.ObservationLogEntry) {
-	for _, observationLog := range logs {
-		log.Info(observationLog)
-	}
+func (p *StdOutLogProducer) Produce(observationLog *types.ObservationLogEntry) {
+	log.Info(observationLog)
 }

--- a/observation-service/monitoring/prometheus.go
+++ b/observation-service/monitoring/prometheus.go
@@ -64,7 +64,7 @@ func GetCounterMap() map[metrics.MetricName]metrics.PrometheusCounterVec {
 
 // GetHistogramMap configures histogram metrics
 func GetHistogramMap() map[metrics.MetricName]metrics.PrometheusHistogramVec {
-	allLabels := []string{"project_name", "service_name", "response_code"}
+	allLabels := []string{"project_name", "service_name", "response_code", "component"}
 
 	histogramMap := map[metrics.MetricName]metrics.PrometheusHistogramVec{
 		RequestDurationMs: prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/observation-service/server/server.go
+++ b/observation-service/server/server.go
@@ -13,6 +13,7 @@ import (
 	upiv1 "github.com/caraml-dev/universal-prediction-interface/gen/go/grpc/caraml/upi/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/soheilhy/cmux"
+	_ "go.uber.org/automaxprocs"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"

--- a/observation-service/services/metric_service.go
+++ b/observation-service/services/metric_service.go
@@ -15,7 +15,7 @@ import (
 
 // MetricService captures the exposed methods for logging performance/health metrics
 type MetricService interface {
-	LogLatencyHistogram(begin time.Time, statusCode int, loggingMetric metrics.MetricName)
+	LogLatencyHistogram(begin time.Time, statusCode int, loggingMetric metrics.MetricName, customLabels map[string]string)
 	LogRequestCount(statusCode int, loggingMetric metrics.MetricName)
 
 	GetLabels(labels map[string]string) map[string]string
@@ -49,9 +49,17 @@ func NewMetricService(deploymentCfg commonconfig.DeploymentConfig, monitoringCfg
 }
 
 // LogLatencyHistogram tracks histogram metrics
-func (ms *metricService) LogLatencyHistogram(begin time.Time, statusCode int, loggingMetric metrics.MetricName) {
+func (ms *metricService) LogLatencyHistogram(
+	begin time.Time,
+	statusCode int,
+	loggingMetric metrics.MetricName,
+	customLabels map[string]string,
+) {
 	baseLabels := map[string]string{
 		"response_code": strconv.Itoa(statusCode),
+	}
+	for k, v := range customLabels {
+		baseLabels[k] = v
 	}
 	labels := ms.GetLabels(baseLabels)
 

--- a/observation-service/services/metric_service_test.go
+++ b/observation-service/services/metric_service_test.go
@@ -62,9 +62,12 @@ func (s *MetricServiceTestSuite) TestGetLabels() {
 
 func (s *MetricServiceTestSuite) TestLogLatencyHistogram() {
 	statusCode := http.StatusOK
+	labels := map[string]string{
+		"component": "test",
+	}
 
 	stdout := testutils.CaptureStderrLogs(func() {
-		s.MetricService.LogLatencyHistogram(time.Now(), statusCode, monitoring.RequestDurationMs)
+		s.MetricService.LogLatencyHistogram(time.Now(), statusCode, monitoring.RequestDurationMs, labels)
 	})
 	s.Suite.Require().Equal("", stdout)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/timber/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/timber/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**:

This PR removes in-memory queue for batch-calling of `Produce` function to send records to configured data sink as there is no need to do so, and removing also helps to alleviate the problem of `OOMKilled` for the pods.

In addition, latency metrics now track the `component` label, so that we can distinguish between latency for `e2e` workflow or producing to a specific sink, i.e `fluentd`/`kafka`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
`NONE`
